### PR TITLE
support windows ndk compile via cygwin

### DIFF
--- a/build-android-setenv.sh
+++ b/build-android-setenv.sh
@@ -105,7 +105,7 @@ fi
 # https://android.googlesource.com/platform/ndk/+/ics-mr0/docs/STANDALONE-TOOLCHAIN.html
 
 ANDROID_TOOLCHAIN=""
-for host in "linux-x86_64" "linux-x86" "darwin-x86_64" "darwin-x86"
+for host in "linux-x86_64" "linux-x86" "darwin-x86_64" "darwin-x86" "windows-x86_64" "windows-x86"
 do
   if [ -d "$ANDROID_NDK_ROOT/toolchains/$_ANDROID_EABI/prebuilt/$host/bin" ]; then
     ANDROID_TOOLCHAIN="$ANDROID_NDK_ROOT/toolchains/$_ANDROID_EABI/prebuilt/$host/bin"


### PR DESCRIPTION
before build set follow env first
export ANDROID_NDK_HOME=/path/to/ndk
export PATH=$PATH:$ANDROID_NDK_HOME/build
